### PR TITLE
Fix URL typo in README & docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
+-  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
+-  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html/>`__
+-  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
+-  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
+-  `radiospectra documentation <https://docs.sunpy.org/projects/radiospectra/>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Getting Help
 ============
 For more information or to ask questions about ``radiospectra`` or any other SunPy library, check out:
 
--  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html/>`__
+-  `sunpy documentation <https://docs.sunpy.org/projects/radiospectra/en/latest/index.html>`__
 -  `SunPy Chat`_
 -  `SunPy mailing list <https://groups.google.com/forum/#!forum/sunpy>`__
 


### PR DESCRIPTION
Removes wrong `/` at the end of the link "sunpy documentation" to `https://docs.sunpy.org/projects/radiospectra/en/latest/index.html/`

(too lazy to open an issue for this, or should I?)