### PR TITLE
Fix #110: Ensure spectrogram plotting correctly handles non-UTC time scales

### DIFF
--- a/changelog/144.bugfix.rst
+++ b/changelog/144.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where plotting spectrograms with non-UTC time scales (e.g., 'tt') would result in time offsets by ensuring conversion to UTC before plotting.

--- a/pytest.ini
+++ b/pytest.ini
@@ -41,3 +41,5 @@ filterwarnings =
     ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
     ignore:File may have been truncated.*
     ignore:pattern has been replaced with the format keyword
+    # pyparsing deprecation warning from old matplotlib in oldestdeps
+    ignore:.*deprecated:pyparsing.warnings.PyparsingDeprecationWarning

--- a/radiospectra/mixins.py
+++ b/radiospectra/mixins.py
@@ -1,3 +1,12 @@
+def _times_utc_datetime(times):
+    """
+    Convert time values to UTC before exposing datetimes, when supported.
+    """
+    if hasattr(times, "utc"):
+        times = times.utc
+    return times.datetime
+
+
 class PcolormeshPlotMixin:
     """
     Class provides plotting functions using `~pcolormesh`.
@@ -35,13 +44,14 @@ class PcolormeshPlotMixin:
         if self.instrument != self.detector:
             title = f"{title}, {self.detector}"
 
+        times = _times_utc_datetime(self.times)
         axes.set_title(title)
-        axes.plot(self.times.datetime[[0, -1]], self.frequencies[[0, -1]], linestyle="None", marker="None")
+        axes.plot(times[[0, -1]], self.frequencies[[0, -1]], linestyle="None", marker="None")
         if self.times.shape[0] == self.data.shape[0] and self.frequencies.shape[0] == self.data.shape[1]:
-            ret = axes.pcolormesh(self.times.datetime, self.frequencies.value, data, shading="auto", **kwargs)
+            ret = axes.pcolormesh(times, self.frequencies.value, data, shading="auto", **kwargs)
         else:
-            ret = axes.pcolormesh(self.times.datetime, self.frequencies.value, data[:-1, :-1], shading="auto", **kwargs)
-        axes.set_xlim(self.times.datetime[0], self.times.datetime[-1])
+            ret = axes.pcolormesh(times, self.frequencies.value, data[:-1, :-1], shading="auto", **kwargs)
+        axes.set_xlim(times[0], times[-1])
         locator = mdates.AutoDateLocator(minticks=4, maxticks=8)
         formatter = mdates.ConciseDateFormatter(locator)
         axes.xaxis.set_major_locator(locator)
@@ -68,6 +78,7 @@ class NonUniformImagePlotMixin:
         if axes is None:
             fig, axes = plt.subplots()
 
+        times = _times_utc_datetime(self.times)
         im = NonUniformImage(axes, interpolation="none", **kwargs)
-        im.set_data(mdates.date2num(self.times.datetime), self.frequencies.value, self.data)
-        axes.images.append(im)
+        im.set_data(mdates.date2num(times), self.frequencies.value, self.data)
+        axes.add_image(im)

--- a/radiospectra/mixins.py
+++ b/radiospectra/mixins.py
@@ -1,3 +1,6 @@
+from astropy.visualization import time_support
+
+
 class PcolormeshPlotMixin:
     """
     Class provides plotting functions using `~pcolormesh`.
@@ -19,8 +22,6 @@ class PcolormeshPlotMixin:
         `matplotlib.collections.QuadMesh`
         """
         from matplotlib import pyplot as plt
-
-        from astropy.visualization import time_support
 
         if axes is None:
             fig, axes = plt.subplots()
@@ -62,8 +63,6 @@ class NonUniformImagePlotMixin:
     def plotim(self, fig=None, axes=None, **kwargs):
         from matplotlib import pyplot as plt
         from matplotlib.image import NonUniformImage
-
-        from astropy.visualization import time_support
 
         if axes is None:
             fig, axes = plt.subplots()

--- a/radiospectra/spectrogram/tests/conftest.py
+++ b/radiospectra/spectrogram/tests/conftest.py
@@ -1,0 +1,3 @@
+import matplotlib
+
+matplotlib.use("Agg")

--- a/radiospectra/spectrogram/tests/test_spectrogrambase.py
+++ b/radiospectra/spectrogram/tests/test_spectrogrambase.py
@@ -1,0 +1,65 @@
+from unittest import mock
+
+import matplotlib
+
+import astropy.units as u
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+
+from astropy.time import Time
+
+from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
+
+
+def _get_spectrogram_with_time_scale(scale):
+    times = Time("2020-01-01T00:00:00", format="isot", scale=scale) + np.arange(4) * u.min
+    frequencies = np.linspace(10, 40, 4) * u.MHz
+    meta = {
+        "observatory": "Test",
+        "instrument": "TestInst",
+        "detector": "TestDet",
+        "start_time": times[0],
+        "end_time": times[-1],
+        "wavelength": np.array([1, 10]) * u.m,
+        "times": times,
+        "freqs": frequencies,
+    }
+    return GenericSpectrogram(np.arange(16).reshape(4, 4), meta)
+
+
+def test_plot_uses_utc_times_for_datetime_conversion():
+    spec = _get_spectrogram_with_time_scale("tt")
+
+    mesh = spec.plot()
+    x_limits = np.array(mesh.axes.get_xlim())
+    expected_utc_limits = mdates.date2num(spec.times.utc.datetime[[0, -1]])
+    expected_tt_limits = mdates.date2num(spec.times.datetime[[0, -1]])
+    plt.close(mesh.axes.figure)
+
+    np.testing.assert_allclose(x_limits, expected_utc_limits)
+    assert not np.allclose(x_limits, expected_tt_limits, rtol=0.0, atol=1e-6)
+
+
+def test_plotim_uses_utc_times_for_datetime_conversion():
+    spec = _get_spectrogram_with_time_scale("tt")
+    fig, axes = plt.subplots()
+
+    with (
+        mock.patch("matplotlib.image.NonUniformImage.set_interpolation", autospec=True),
+        mock.patch("matplotlib.image.NonUniformImage.set_data", autospec=True) as set_data,
+    ):
+        spec.plotim(fig=fig, axes=axes)
+    plt.close(fig)
+
+    _, x_values, y_values, image = set_data.call_args.args
+    expected_utc = mdates.date2num(spec.times.utc.datetime)
+    expected_tt = mdates.date2num(spec.times.datetime)
+
+    np.testing.assert_allclose(x_values, expected_utc)
+    assert not np.allclose(x_values, expected_tt, rtol=0.0, atol=1e-6)
+    np.testing.assert_allclose(y_values, spec.frequencies.value)
+    np.testing.assert_allclose(image, spec.data)


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed
Please also include relevant motivation and context.
-->
Fixes an issue where plotting data with different time scales i.e. 'tt' and 'utc' would result in time offsets because `GenericSpectrogram` plotting was using the raw time scale components directly via `.datetime`. Corrects the plotting logic to always convert to UTC first.
Closes #110

## What changed
- Modified `radiospectra/mixins.py` to ensure `self.times` is converted to UTC before generating `datetime` objects for plotting.
- Added internal helper `_times_utc_datetime` to handle the conversion if supported by the time object.
- Validated that plotting correctly aligns with UTC time regardless of input time scale.

@samaloney, Let me know your thoughts on this!!