### PR TITLE
feature: add frequency_at_index method to GenericSpectrogram (#129).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,13 +24,33 @@ To see the latest changes in ``radiospectra`` see our `changelog <https://docs.s
 
 Installation
 ============
+## Development Setup
 
-The recommended way to install ``radiospectra`` is with `miniforge <https://github.com/conda-forge/miniforge#miniforge3>`__.
-To install ``radiospectra`` once miniforge is installed run the following command:
+The recommended way to install ``radiospectra`` is:
 
-.. code:: bash
+### Prerequisites
+- Python 3.12
+- [miniforge](https://github.com/conda-forge/miniforge) (recommended) or venv
 
-    $ conda install radiospectra
+### Conda (Recommended)
+```bash
+conda create -n radiospectra-dev python=3.12
+conda activate radiospectra-dev
+git clone https://github.com/sunpy/radiospectra
+cd radiospectra
+pip install -e '.[dev,docs]'  # Editable + testing/docs extras
+
+### venv/pip
+
+ python3.12 -m venv .venv
+source .venv/bin/activate    # Linux/Mac
+# .venv\Scripts\activate     # Windows
+pip install -e '.[dev,docs]'
+
+### Verify using:
+
+pytest tests/  # Run tests
+
 
 For detailed installation instructions, see the `installation guide <https://docs.sunpy.org/en/stable/guide/installation.html>`__ in the ``sunpy`` docs.
 

--- a/README.rst
+++ b/README.rst
@@ -24,33 +24,13 @@ To see the latest changes in ``radiospectra`` see our `changelog <https://docs.s
 
 Installation
 ============
-## Development Setup
 
-The recommended way to install ``radiospectra`` is:
+The recommended way to install ``radiospectra`` is with `miniforge <https://github.com/conda-forge/miniforge#miniforge3>`__.
+To install ``radiospectra`` once miniforge is installed run the following command:
 
-### Prerequisites
-- Python 3.12
-- [miniforge](https://github.com/conda-forge/miniforge) (recommended) or venv
+.. code:: bash
 
-### Conda (Recommended)
-```bash
-conda create -n radiospectra-dev python=3.12
-conda activate radiospectra-dev
-git clone https://github.com/sunpy/radiospectra
-cd radiospectra
-pip install -e '.[dev,docs]'  # Editable + testing/docs extras
-
-### venv/pip
-
- python3.12 -m venv .venv
-source .venv/bin/activate    # Linux/Mac
-# .venv\Scripts\activate     # Windows
-pip install -e '.[dev,docs]'
-
-### Verify using:
-
-pytest tests/  # Run tests
-
+    $ conda install radiospectra
 
 For detailed installation instructions, see the `installation guide <https://docs.sunpy.org/en/stable/guide/installation.html>`__ in the ``sunpy`` docs.
 

--- a/changelog/172.feature.rst
+++ b/changelog/172.feature.rst
@@ -1,1 +1,1 @@
-Added ``frequency_at_index`` method to ``GenericSpectrogram`` class
+Added frequency_at_index method to GenericSpectrogram class

--- a/changelog/172.feature.rst
+++ b/changelog/172.feature.rst
@@ -1,1 +1,1 @@
-Added a frequency_at_index method to GenericSpectrogram to allow index-to-frequency mapping.
+Added ``frequency_at_index`` method to ``GenericSpectrogram`` class

--- a/changelog/172.feature.rst
+++ b/changelog/172.feature.rst
@@ -1,0 +1,1 @@
+Added a frequency_at_index method to GenericSpectrogram to allow index-to-frequency mapping.

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -107,3 +107,12 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
             f" {self.wavelength.min} - {self.wavelength.max},"
             f" {self.start_time.isot} to {self.end_time.isot}>"
         )
+    def frequency_at_index(self, index):
+        """
+        Returns the frequency at a specific index.
+        """
+        freq = self.frequencies
+        max_freq= len(freq)
+        if index < 0 or index >= max_freq:
+            raise IndexError(f"Index {index} out of range for frequency axis with size {max_freq}.")
+        return freq[index]

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -107,12 +107,13 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
             f" {self.wavelength.min} - {self.wavelength.max},"
             f" {self.start_time.isot} to {self.end_time.isot}>"
         )
+
     def frequency_at_index(self, index):
         """
         Returns the frequency at a specific index.
         """
         freq = self.frequencies
-        max_freq= len(freq)
+        max_freq = len(freq)
         if index < 0 or index >= max_freq:
             raise IndexError(f"Index {index} out of range for frequency axis with size {max_freq}.")
         return freq[index]


### PR DESCRIPTION
Added the frequency_at_index method to the GenericSpectrogram class. This method allows users to retrieve the physical frequency value associated with a specific array index along the frequency axis.

The implementation includes:

-Validation logic to ensure the provided index is within the bounds of the frequency axis.
-Raising a descriptive IndexError if the index is out of range, helping users debug data mapping issues.

AI Assistance Disclosure

AI tools were used for :

[x] Code generation (Initial drafting of the method structure)
[x] Research and understanding (Clarifying rST syntax for the changelog)

Note: I have manually verified the logic using a local test suite with dummy spectrogram data to ensure the mapping is accurate.

Related Issues
Closes #129