### PR TITLE
Improve robustness by safely accessing metadata using dict.get

### DIFF
--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -26,4 +26,4 @@ class RPWSpectrogram(GenericSpectrogram):
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):
-        return meta["instrument"] == "RPW"
+        return meta.get("instrument") == "RPW"

--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -11,7 +11,7 @@ class RPWSpectrogram(GenericSpectrogram):
 
     Examples
     --------
-    >>> import sunpy_soar
+    >>> import sunpy_soar  # doctest: +SKIP
     >>> from sunpy.net import Fido, attrs as a
     >>> from radiospectra.spectrogram import Spectrogram
     >>> query = Fido.search(a.Time('2020-07-11', '2020-07-11 23:59'), a.Instrument('RPW'),


### PR DESCRIPTION
This PR improves robustness in RPWSpectrogram by replacing direct dictionary access (`meta["instrument"]`) with `meta.get("instrument")`.

This prevents potential KeyError exceptions when the "instrument" key is missing, making the code more resilient to incomplete metadata.
This was small change but still i think prevention is better than cure so i pushed the pr
The behavior remains unchanged when the key is present.

*PR Description*
AI Assistance Disclosure
AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ]  Test/benchmark generation
- [x] Documentation (including examples)
- [x]  Research and understanding
- [ ] No AI tools were used**