### PR TITLE
Add test for missing instrument metadata in RPWSpectrogram

### DIFF
--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -26,4 +26,4 @@ class RPWSpectrogram(GenericSpectrogram):
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):
-        return meta["instrument"] == "RPW"
+        return meta.get("instrument") == "RPW"

--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -11,7 +11,7 @@ class RPWSpectrogram(GenericSpectrogram):
 
     Examples
     --------
-    >>> import sunpy_soar
+    >>> import sunpy_soar  # doctest: +SKIP
     >>> from sunpy.net import Fido, attrs as a
     >>> from radiospectra.spectrogram import Spectrogram
     >>> query = Fido.search(a.Time('2020-07-11', '2020-07-11 23:59'), a.Instrument('RPW'),

--- a/radiospectra/spectrogram/sources/tests/test_solo_rpw.py
+++ b/radiospectra/spectrogram/sources/tests/test_solo_rpw.py
@@ -117,3 +117,12 @@ def test_solo_rpw_hfr(parse_path_moc):
     assert spec.end_time.datetime == datetime(2024, 3, 24, 0, 0, 0, 0)
     assert spec.wavelength.min == 425 * u.kHz
     assert spec.wavelength.max == 16325 * u.kHz
+
+def test_rpw_missing_instrument_key():
+    from radiospectra.spectrogram.sources.rpw import RPWSpectrogram
+
+    meta = {}  # missing "instrument"
+
+    result = RPWSpectrogram.is_datasource_for(None, meta)
+
+    assert result is False


### PR DESCRIPTION
This PR adds a test to check the behavior of RPWSpectrogram when the
"instrument" key is missing from the metadata.

Previously, accessing this key directly could raise an error. With the
recent change to use a safer access method, this test ensures that the
function handles such cases gracefully and returns False instead of
failing.

This helps improve reliability and prevents similar issues in the future.

**PR Description**
AI tools were used for:

- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used