### PR TITLE
Add coordinate lookup methods to GenericSpectrogram

### DIFF
--- a/changelog/129.feature.rst
+++ b/changelog/129.feature.rst
@@ -1,0 +1,3 @@
+Add ``frequency_at_index``, ``time_at_index``, ``index_at_frequency``, and ``index_at_time``
+methods to `~radiospectra.spectrogram.GenericSpectrogram` for converting between
+array indices and physical coordinates.

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from radiospectra.exceptions import SpectraMetaValidationError
 from radiospectra.mixins import NonUniformImagePlotMixin, PcolormeshPlotMixin
 
@@ -100,6 +102,66 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
                 err_message.append(msg.format(ax))
         if err_message:
             raise SpectraMetaValidationError("\n".join(err_message))
+
+    def frequency_at_index(self, index):
+        """
+        Return the frequency at a given index along the frequency axis.
+
+        Parameters
+        ----------
+        index : int
+            Index along the frequency axis.
+
+        Returns
+        -------
+        `~astropy.units.Quantity`
+        """
+        return self.frequencies[index]
+
+    def time_at_index(self, index):
+        """
+        Return the time at a given index along the time axis.
+
+        Parameters
+        ----------
+        index : int
+            Index along the time axis.
+
+        Returns
+        -------
+        `~astropy.time.Time`
+        """
+        return self.times[index]
+
+    def index_at_frequency(self, frequency):
+        """
+        Return the index along the frequency axis closest to a given frequency.
+
+        Parameters
+        ----------
+        frequency : `~astropy.units.Quantity`
+            The frequency to search for.
+
+        Returns
+        -------
+        int
+        """
+        return int(np.argmin(np.abs(self.frequencies - frequency)))
+
+    def index_at_time(self, time):
+        """
+        Return the index along the time axis closest to a given time.
+
+        Parameters
+        ----------
+        time : `~astropy.time.Time`
+            The time to search for.
+
+        Returns
+        -------
+        int
+        """
+        return int(np.argmin(np.abs(self.times - time)))
 
     def __repr__(self):
         return (

--- a/radiospectra/spectrogram/tests/test_spectrogrambase.py
+++ b/radiospectra/spectrogram/tests/test_spectrogrambase.py
@@ -135,3 +135,34 @@ def test_plotim_uses_time_support_for_datetime_conversion(make_spectrogram):
     np.testing.assert_allclose(x_values, expected_tt)
     np.testing.assert_allclose(y_values, spec.frequencies.value)
     np.testing.assert_allclose(image, spec.data)
+
+
+def test_frequency_at_index(make_spectrogram):
+    spec = make_spectrogram(np.array([10, 20, 30, 40]) * u.MHz)
+
+    assert spec.frequency_at_index(0) == 10 * u.MHz
+    assert spec.frequency_at_index(2) == 30 * u.MHz
+
+
+def test_time_at_index(make_spectrogram):
+    spec = make_spectrogram(np.array([10, 20, 30, 40]) * u.MHz)
+
+    assert spec.time_at_index(0) == spec.times[0]
+    assert spec.time_at_index(3) == spec.times[3]
+
+
+def test_index_at_frequency(make_spectrogram):
+    spec = make_spectrogram(np.array([10, 20, 30, 40]) * u.MHz)
+
+    # 21 MHz is closer to 20 than 30, so index 1
+    assert spec.index_at_frequency(21 * u.MHz) == 1
+    # 39 MHz is closest to 40 MHz, index 3
+    assert spec.index_at_frequency(39 * u.MHz) == 3
+
+
+def test_index_at_time(make_spectrogram):
+    spec = make_spectrogram(np.array([10, 20, 30, 40]) * u.MHz)
+
+    # 10 seconds after times[1] is still closer to times[1] than times[2]
+    t = spec.times[1] + 10 * u.s
+    assert spec.index_at_time(t) == 1


### PR DESCRIPTION
## Description

This PR adds four coordinate lookup methods to the `GenericSpectrogram` base class to allow for easy conversion between array indices and physical units (frequency and time).

Specifically, it implements:
- `frequency_at_index(index)` and `time_at_index(index)` for direct coordinate retrieval.
- `index_at_frequency(frequency)` and `index_at_time(time)` using a nearest-neighbor approach with `np.argmin` on the absolute differences.

These methods are foundational for making `radiospectra` more coordinate-aware and align with the goals for my GSoC 2026 project proposal to modernize the package's data structures.

I've added unit tests for all four methods in `radiospectra/spectrogram/tests/test_spectrogrambase.py` and included a changelog fragment.

### Issue(s) addressed
- Closes #129

### Checklist
- [x] I have followed the [Coding Standards](https://docs.sunpy.org/en/latest/dev_guide/contents/code_standards.html).
- [x] I have updated the documentation where necessary.
- [x] I have added tests for my changes.
- [x] I have added a changelog fragment.

### Usage of Generative AI
- [x] I have used generative AI tools as an aid in developing this code.
- [x] I fully understand the proposed changes and can explain why they are the correct approach.

**Explanation of AI usage:** I used an AI assistant to help me learn and understand the codebase better. This was used as a learning and coding aid while I worked on the implementation. All of the code was written by me and checked throughly.
