### PR TITLE
Adds `peek()` function for GenericSpectrogram

### DIFF
--- a/changelog/188.feature.rst
+++ b/changelog/188.feature.rst
@@ -1,0 +1,2 @@
+Add a ``peek()`` method to ``GenericSpectrogram``, which gives it a quick-look plotting functionality
+similar to ``sunpy.map.Map.peek()`` and ``radiospectra.spectrum.Spectrum.peek()``.

--- a/changelog/peek.feature.rst
+++ b/changelog/peek.feature.rst
@@ -1,0 +1,2 @@
+Add a ``peek()`` method to ``GenericSpectrogram``, which gives it a quick-look plotting functionality
+similar to ``sunpy.map.Map.peek()`` and ``radiospectra.spectrum.Spectrum.peek()``.

--- a/changelog/peek.feature.rst
+++ b/changelog/peek.feature.rst
@@ -1,2 +1,0 @@
-Add a ``peek()`` method to ``GenericSpectrogram``, which gives it a quick-look plotting functionality
-similar to ``sunpy.map.Map.peek()`` and ``radiospectra.spectrum.Spectrum.peek()``.

--- a/docs/code_ref/spectrogram.rst
+++ b/docs/code_ref/spectrogram.rst
@@ -1,4 +1,28 @@
 `radiospectra.spectrogram`
 ==========================
 
+The `radiospectra.spectrogram` module provides classes and utilities for working with dynamic solar radio spectrograms.
+
+Visualizing Spectrograms
+------------------------
+
+All spectrogram objects in ``radiospectra`` inherit from :class:`~radiospectra.spectrogram.GenericSpectrogram`, which provides a :meth:`~radiospectra.spectrogram.GenericSpectrogram.peek` method for quick-look visualization.
+
+The ``peek()`` method creates a new figure and plots the spectrogram with sensible defaults, including an optional colorbar.
+
+.. plot::
+    :include-source:
+
+    from radiospectra.spectrogram import Spectrogram
+    import radiospectra.net
+    from sunpy.net import Fido, attrs as a
+
+    # Search and download data
+    query = Fido.search(a.Time('2021/05/07 00:00', '2021/05/07 01:00'), a.Instrument.eovsa)
+    files = Fido.fetch(query)
+
+    # Create spectrogram and peek
+    spec = Spectrogram(files[0])
+    spec.peek()
+
 .. automodapi:: radiospectra.spectrogram

--- a/docs/code_ref/spectrogram.rst
+++ b/docs/code_ref/spectrogram.rst
@@ -13,16 +13,30 @@ The ``peek()`` method creates a new figure and plots the spectrogram with sensib
 .. plot::
     :include-source:
 
-    from radiospectra.spectrogram import Spectrogram
-    import radiospectra.net
-    from sunpy.net import Fido, attrs as a
+    import numpy as np
+    import astropy.units as u
+    from astropy.time import Time
+    from radiospectra.spectrogram import GenericSpectrogram
 
-    # Search and download data
-    query = Fido.search(a.Time('2021/05/07 00:00', '2021/05/07 01:00'), a.Instrument.eovsa)
-    files = Fido.fetch(query)
+    # Create artificial spectrogram data
+    times = Time("2021-01-01T00:00:00") + np.arange(100) * u.min
+    freqs = np.linspace(10, 100, 50) * u.MHz
+    data = np.random.rand(50, 100)
 
-    # Create spectrogram and peek
-    spec = Spectrogram(files[0])
+    # Define minimal metadata
+    meta = {
+        "observatory": "Example Data",
+        "instrument": "Mock Instrument",
+        "detector": "Mock Detector",
+        "start_time": times[0],
+        "end_time": times[-1],
+        "wavelength": u.Quantity([1, 10], unit=u.m),
+        "times": times,
+        "freqs": freqs,
+    }
+
+    # Instantiate and peek
+    spec = GenericSpectrogram(data, meta)
     spec.peek()
 
 .. automodapi:: radiospectra.spectrogram

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -1,3 +1,5 @@
+from sunpy.visualization import peek_show
+
 from radiospectra.exceptions import SpectraMetaValidationError
 from radiospectra.mixins import NonUniformImagePlotMixin, PcolormeshPlotMixin
 
@@ -108,25 +110,22 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
             f" {self.start_time.isot} to {self.end_time.isot}>"
         )
 
-    def peek(self, **kwargs):
+    @peek_show
+    def peek(self, show_colorbar=True, **kwargs):
         """
-        Displays a quick-look plot of the Spectrogram with a colorbar.
+        Displays a quick-look plot of the Spectrogram.
 
         Parameters
         ----------
+        show_colorbar : `bool`, optional
+            Whether to show a colorbar. Defaults to `True`.
         **kwargs : `dict`
             Any additional keyword arguments are passed to `~radiospectra.spectrogram.GenericSpectrogram.plot`.
-
-        Returns
-        -------
-        `matplotlib.figure.Figure`
-            The figure object containing the plot.
         """
         import matplotlib.pyplot as plt
 
         figure = plt.figure()
-        axes = figure.add_subplot(111)
+        axes = figure.add_subplot()
         ret = self.plot(axes=axes, **kwargs)
-        figure.colorbar(ret)
-        figure.show()
-        return figure
+        if show_colorbar:
+            figure.colorbar(ret)

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -107,3 +107,26 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
             f" {self.wavelength.min} - {self.wavelength.max},"
             f" {self.start_time.isot} to {self.end_time.isot}>"
         )
+
+    def peek(self, **kwargs):
+        """
+        Displays a quick-look plot of the Spectrogram with a colorbar.
+
+        Parameters
+        ----------
+        **kwargs : `dict`
+            Any additional keyword arguments are passed to `~radiospectra.spectrogram.GenericSpectrogram.plot`.
+
+        Returns
+        -------
+        `matplotlib.figure.Figure`
+            The figure object containing the plot.
+        """
+        import matplotlib.pyplot as plt
+
+        figure = plt.figure()
+        axes = figure.add_subplot(111)
+        ret = self.plot(axes=axes, **kwargs)
+        figure.colorbar(ret)
+        figure.show()
+        return figure


### PR DESCRIPTION
## PR Description

Fixes #185 

**Summary:**
This PR adds a `peek()` method to the `GenericSpectrogram` base class to provide quick-look plotting functionality, aligning the object with the design philosophy and API conventions already established by `sunpy.map.Map.peek()` and `radiospectra.spectrum.Spectrum.peek()`.

**Motivation and Context:**
Currently, taking a "quick look" at a `GenericSpectrogram` with a colorbar requires users to write roughly 5 lines of boilerplate code: manually importing matplotlib, setting up a figure and subplot, calling the underlying `.plot()` method, and manually passing the returned `QuadMesh` to a `fig.colorbar(ret)` call.

Providing a built-in `peek()` method reduces this to a single `spec.peek()` call, enabling users to immediately view their spectral data with sensible visualization defaults (like automatic colorbars and labels) upon instantiation.

**Changes:**
- Added `peek(self, **kwargs)` to `GenericSpectrogram` in `spectrogrambase.py`.
- The method safely wraps `self.plot(**kwargs)` (inherited from `PcolormeshPlotMixin`), catching the returned `QuadMesh` and automatically mapping it to a `Figure.colorbar()`. All extra `**kwargs` are cleanly passed down into the `pcolormesh` logic.
- Included an RST changelog feature entry.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate usage of AI.
-->

AI tools were used for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.
