### PR TITLE
Improve data validation and documentation in Generic Spectrogram

### DIFF
--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -15,7 +15,8 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
     meta : `dict-like`
         Meta data for the spectrogram.
     data : `numpy.ndarray`
-        The spectrogram data itself a 2D array.
+        2D array of spectrogram intensities with shape (n_frequencies, n_times).
+        Missing or invalid values (e.g., NaNs) may be present in observational data.
     """
 
     _registry = {}

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -26,8 +26,13 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
             cls._registry[cls] = cls.is_datasource_for
 
     def __init__(self, data, meta, **kwargs):
-        self.data = data
-        self.meta = meta
+        self.data = np.asanyarray(data)
+        self.data = np.ma.masked_invalid(self.data)
+        if self.data.ndim != 2:
+    raise ValueError("Spectrogram data must be 2-dimensional.")
+        
+        
+     self.meta = meta
         self._validate_meta()
 
     @property

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from radiospectra.exceptions import SpectraMetaValidationError
 from radiospectra.mixins import NonUniformImagePlotMixin, PcolormeshPlotMixin
 


### PR DESCRIPTION
This PR improves robustness of the Generic Spectrogram class by:
- Converting input data to a NumPy array  
- Masking invalid values (e.g., NaNs)  
- Adding a dimensionality check  
- Improving docstring clarity  

These changes improve handling of real observational data while maintaining compatibility.