### PR TITLE
Using NDCube and NDMeta for `GenericSpectrogram`

### DIFF
--- a/radiospectra/mixins.py
+++ b/radiospectra/mixins.py
@@ -84,12 +84,12 @@ class PcolormeshPlotMixin:
             if converter_x is not None and not getattr(axes.xaxis, "_converter_is_explicit", False):
                 _set_axis_converter(axes.xaxis, converter_x)
 
-            axes.plot(self.times[[0, -1]], self.frequencies[[0, -1]], linestyle="None", marker="None")
-            if self.times.shape[0] == self.data.shape[0] and self.frequencies.shape[0] == self.data.shape[1]:
-                ret = axes.pcolormesh(self.times, self.frequencies, data, shading="auto", **kwargs)
+            axes.plot(self.time[[0, -1]], self.frequency[[0, -1]], linestyle="None", marker="None")
+            if self.time.shape[0] == self.data.shape[0] and self.frequency.shape[0] == self.data.shape[1]:
+                ret = axes.pcolormesh(self.time, self.frequency, data, shading="auto", **kwargs)
             else:
-                ret = axes.pcolormesh(self.times, self.frequencies, data[:-1, :-1], shading="auto", **kwargs)
-            axes.set_xlim(self.times[0], self.times[-1])
+                ret = axes.pcolormesh(self.time, self.frequency, data[:-1, :-1], shading="auto", **kwargs)
+            axes.set_xlim(self.time[0], self.time[-1])
             fig.autofmt_xdate()
 
         # Set current axes/image if pyplot is being used (makes colorbar work)
@@ -120,12 +120,12 @@ class NonUniformImagePlotMixin:
             if converter_x is not None and not getattr(axes.xaxis, "_converter_is_explicit", False):
                 _set_axis_converter(axes.xaxis, converter_x)
 
-            axes.yaxis.update_units(self.frequencies)
-            frequencies = axes.yaxis.convert_units(self.frequencies)
+            axes.yaxis.update_units(self.frequency)
+            frequencies = axes.yaxis.convert_units(self.frequency)
 
-            axes.plot(self.times[[0, -1]], self.frequencies[[0, -1]], linestyle="None", marker="None")
+            axes.plot(self.time[[0, -1]], self.frequency[[0, -1]], linestyle="None", marker="None")
             im = NonUniformImage(axes, interpolation="none", **kwargs)
-            im.set_data(axes.convert_xunits(self.times), frequencies, self.data)
+            im.set_data(axes.convert_xunits(self.time), frequencies, self.data)
             axes.add_image(im)
-            axes.set_xlim(self.times[0], self.times[-1])
+            axes.set_xlim(self.time[0], self.time[-1])
             axes.set_ylim(frequencies[0], frequencies[-1])

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -1,0 +1,30 @@
+"""
+Abstract base class for dynamic spectra
+"""
+import abc
+
+from ndcube.meta import NDMeta
+from sunraster.meta import MetaABC
+
+__all__ = [
+    'SpectrogramMetaABC',
+    'SpectrogramMeta',
+]
+
+
+class SpectrogramMetaABC(MetaABC):
+
+    @abc.abstractmethod
+    def target(self):
+        """The target coordinate of the observation."""
+        pass
+
+
+class SpectrogramMeta(NDMeta,SpectrogramMetaABC):
+
+    _registry = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if hasattr(cls, "is_datasource_for"):
+            cls._registry[cls] = cls.is_datasource_for

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -20,7 +20,7 @@ class SpectrogramMetaABC(MetaABC):
         pass
 
 
-class SpectrogramMeta(NDMeta,SpectrogramMetaABC):
+class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
 
     _registry = {}
 

--- a/radiospectra/spectrogram/sources/meta.py
+++ b/radiospectra/spectrogram/sources/meta.py
@@ -1,0 +1,4 @@
+"""
+Source-specific metadata classes
+"""
+from radiospectra.spectrogram.meta import SpectrogramMeta

--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -1,3 +1,5 @@
+from sunpy.coordinates import get_horizons_coord
+
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
 __all__ = ["RPWSpectrogram"]
@@ -27,3 +29,8 @@ class RPWSpectrogram(GenericSpectrogram):
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):
         return meta["instrument"] == "RPW"
+
+    @property
+    def observer_coordinate(self):
+        "Position of Solar Orbiter at the start of the observing interval."
+        return get_horizons_coord('SolO', time=self.start_time)

--- a/radiospectra/spectrogram/spectrogram_factory.py
+++ b/radiospectra/spectrogram/spectrogram_factory.py
@@ -34,6 +34,7 @@ from sunpy.util.metadata import MetaDict
 from sunpy.util.util import expand_list
 
 from radiospectra.exceptions import NoSpectrogramInFileError, SpectraMetaValidationError
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 from radiospectra.utils import subband_to_freq
 
@@ -699,4 +700,4 @@ class SpectrogramFactory(BasicRegistrationFactory):
             raise ValueError(f"Unrecognized IDL .save file: {file}")
 
 
-Spectrogram = SpectrogramFactory(registry=GenericSpectrogram._registry, default_widget_type=GenericSpectrogram)
+Spectrogram = SpectrogramFactory(registry=SpectrogramMeta._registry, default_widget_type=SpectrogramMeta)

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -1,109 +1,23 @@
-from radiospectra.exceptions import SpectraMetaValidationError
-from radiospectra.mixins import NonUniformImagePlotMixin, PcolormeshPlotMixin
+import ndcube
+
+from radiospectra.utils import build_spectrogram_wcs
+from radiospectra.spectrogram.meta import SpectrogramMeta
 
 __all__ = ["GenericSpectrogram"]
 
 
-class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin):
-    """
-    Base spectrogram class all spectrograms inherit.
+class GenericSpectrogram(ndcube.NDCube):
 
-    Attributes
-    ----------
-    meta : `dict-like`
-        Meta data for the spectrogram.
-    data : `numpy.ndarray`
-        The spectrogram data itself a 2D array.
-    """
-
-    _registry = {}
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        if hasattr(cls, "is_datasource_for"):
-            cls._registry[cls] = cls.is_datasource_for
-
-    def __init__(self, data, meta, **kwargs):
-        self.data = data
-        self.meta = meta
-        self._validate_meta()
+    @classmethod
+    def from_arrays(self, time, frequency, data, meta):
+        gwcs = build_spectrogram_wcs(frequency, time)
+        return super().__init__(data, gwcs, meta=meta)
 
     @property
-    def observatory(self):
-        """
-        The name of the observatory which recorded the spectrogram.
-        """
-        return self.meta["observatory"].upper()
+    def time(self):
+        return self.axis_world_coords('time')[0]
 
     @property
-    def instrument(self):
-        """
-        The name of the instrument which recorded the spectrogram.
-        """
-        return self.meta["instrument"].upper()
+    def frequency(self):
+        return self.axis_world_coords('frequency')[0]
 
-    @property
-    def detector(self):
-        """
-        The detector which recorded the spectrogram.
-        """
-        return self.meta["detector"].upper()
-
-    @property
-    def start_time(self):
-        """
-        The start time of the spectrogram.
-        """
-        return self.meta["start_time"]
-
-    @property
-    def end_time(self):
-        """
-        The end time of the spectrogram.
-        """
-        return self.meta["end_time"]
-
-    @property
-    def wavelength(self):
-        """
-        The wavelength range of the spectrogram.
-        """
-        return self.meta["wavelength"]
-
-    @property
-    def times(self):
-        """
-        The times of the spectrogram.
-        """
-        return self.meta["times"]
-
-    @property
-    def frequencies(self):
-        """
-        The frequencies of the spectrogram.
-        """
-        return self.meta["freqs"]
-
-    def _validate_meta(self):
-        """
-        Validates the meta-information associated with a Spectrogram.
-
-        This method includes very basic validation checks which apply to
-        all of the kinds of files that radiospectra can read.
-        Datasource-specific validation should be handled in the relevant
-        file in the radiospectra.spectrogram.sources.
-        """
-        msg = "Spectrogram coordinate units for {} axis not present in metadata."
-        err_message = []
-        for i, ax in enumerate(["times", "freqs"]):
-            if self.meta.get(ax) is None:
-                err_message.append(msg.format(ax))
-        if err_message:
-            raise SpectraMetaValidationError("\n".join(err_message))
-
-    def __repr__(self):
-        return (
-            f"<{self.__class__.__name__} {self.observatory}, {self.instrument}, {self.detector}"
-            f" {self.wavelength.min} - {self.wavelength.max},"
-            f" {self.start_time.isot} to {self.end_time.isot}>"
-        )

--- a/radiospectra/utils.py
+++ b/radiospectra/utils.py
@@ -1,6 +1,8 @@
 import astropy.units as u
 
-__all__ = ["subband_to_freq"]
+from ndcube.extra_coords.table_coord import QuantityTableCoordinate, TimeTableCoordinate
+
+__all__ = ["subband_to_freq", "build_spectrogram_wcs"]
 
 
 def subband_to_freq(subband, obs_mode):
@@ -27,3 +29,19 @@ def subband_to_freq(subband, obs_mode):
     clock = clock_dict[obs_mode]
     freq = (nyq_zone - 1 + subband / 512) * (clock / 2)
     return freq * u.MHz  # MHz
+
+
+@u.quantity_input
+def build_spectrogram_wcs(frequency: u.Hz, time, reference_time=None):
+    """
+    Build a generalized world coordinate system (gwcs) from time and frequency arrays.
+
+    Parameters
+    ----------
+    frequency: `astropy.units.Quantity`
+    time: `astropy.time.Time`
+    reference_time
+    """
+    time_coord = TimeTableCoordinate(time, reference_time=reference_time)
+    frequency_coord = QuantityTableCoordinate(frequency, names='frequency', physical_types='phys.frequency')
+    return (time_coord & frequency_coord).wcs

--- a/radiospectra/utils.py
+++ b/radiospectra/utils.py
@@ -40,7 +40,9 @@ def build_spectrogram_wcs(frequency: u.Hz, time, reference_time=None):
     ----------
     frequency: `astropy.units.Quantity`
     time: `astropy.time.Time`
-    reference_time
+    reference_time: `astropy.time.Time`, optional
+        Reference time for the time coordinate. Defaults to the first time in the
+        time coordinate.
     """
     time_coord = TimeTableCoordinate(time, reference_time=reference_time)
     frequency_coord = QuantityTableCoordinate(frequency, names='frequency', physical_types='phys.frequency')


### PR DESCRIPTION
*Caveat: Just putting up this PR to illustrate some of the ideas that came out of the Lorentz Center Workshop last week. Nothing works right now, this is not even a full implementation and it may never be. It's completely find if this particular PR is never merged, but the general idea should be pursued.*

The basic idea here is to experiment with building `GenericSpectrogram` on top of `NDCube` rather than have it be its own object. Additionally, all of the derived metadata now lives on a separate metadata class. I've added some implementation notes, specifically separating out notes about the actual class, the metadata, and the factory. I've provided what I think is a reasonable path forward, but this likely needs more fleshing out.

@nabobalis please chime in if I missed anything here. I'm trying to reconstitute some of our conversations several days later.

See #209 for more context as to why we are pursuing this.

## `GenericSpectrogram`

- Inherits from `NDCube`
- This subclass is intentionally minimal and adding any additional properties should be done very cautiously.
  - The intention is to eventually delete this subclass and just use NDCube once axis-specific properties are possible
  - To this end, adding methods to this subclass should also be avoided.
- Convenience properties are added for accessing the time and frequency arrays.
- Added a util function for building a gwcs from time and frequency arrays.
  - In principle, this WCS can be any APE-14-compliant WCS
  - Using a gwcs is likely easiest given that frequency is almost always spaced non-linearly and time can be as well.

## Metadata

- All metadata properties have been moved to the `.meta` property of the `NDCube`
- The metadata is a `SpectrogramMeta` object which itself is a subclass of [`NDMeta`](https://github.com/sunpy/ndcube/blob/50eb98620d3968e18802f0ef09f7326a10b97970/ndcube/meta.py#L12)
- It also inherits from the abstract base class `SpectrogramMetaABC` which itself is a subclass of [`MetaABC`](https://github.com/sunpy/sunraster/blob/9bb55001a2aa9e7656e1388d84aee3ea55914aa6/sunraster/meta.py#L8)
- `MetaABC` enforces the existence of a number of metadata properties
- Compared to both the preexisting metadata properties on `GenericSpectrogram` and those identified during the workshop, the only property not already on `MetaABC` is `target` (the pointing coordinates of the observatory). This is why `SpectogramMetaABC` exists.
- `SpectrogramMeta` exists in order to inherit from `SpectrogramMetaABC` and to enable registration of source-specific metadata classes.
- Note that the WCS (the time/frequency axes) are *not* part of the metadata
- Polarization should be an extracoord

## Factory

- The factory should continue to produce `GenericSpectrogram` instances
- In contrast to how the current factory works (and how the `MapFactory` works in `sunpy`), the factory should always produce `GenericSpectrogram` instances, but with source-specific metadata class instances attached.
- This is why the subclass registry now lives on `SpectrogramMeta`
- Trying to enforce a separation between data, WCS, and all other metadata
  - This is challenging because how the data and WCS are parsed is also source-specific and in principle, the metadata object does not know about the data or WCS properties.
  - So where does this source-specific parsing live? 
  - The problem boils down to their not being a consistent file format across the many sources (unlike the `sunpy` Map/MapFactory which (essentially) only deals with FITS files)
- To some extent, there are really *three* different factories needed: data, WCS, and metadata, but we only want one.
  - We should be able to reduce this to one.  

## TODOs

A very rough, zeroth-order work plan. I'm not exactly sure the ordering here is ideal.

0. Review whether all of the needed metadata properties exist already on `SpectrogramMeta`. Add them to `SpectrogramMetaABC` if they don't already or if they can be derived from pre-existing metadata implement them as properties directly on `SpectrogramMeta`.
1. Implement the source-specific metadata classes.
    - These should all be `SpectrogramMeta` subclasses
    - To start with, it may be easiest to do all the file parsing on each source-specific class, even if their is code duplication across classes. Refactoring can be done later to reduce duplication.
    - It may also be best to parse the data and the time/frequency axes here as well and pass these back to the `GenericSpectrogram` constructor. This is awkward, but can be cleaned up later
2. Refactor the factory to use these metadata subclasses and produce `GenericSpectrogram` instances.
3. Refactor the plotting mixins to be similar to the `NDCube` plotting mixins.
