### PR TITLE
Finalize sunpy >7.0 support

### DIFF
--- a/changelog/237.bugfix.rst
+++ b/changelog/237.bugfix.rst
@@ -1,1 +1,1 @@
-Removed legacy sunpy version check and fallback scraper pattern in ``EOVSAClient`` since `sunpy[net]>=7.0` is now mandated.
+Remove legacy sunpy version check and fallback scraper pattern in `~radiospectra.net.sources.eovsa.EOVSAClient` since `sunpy[net]>=7.0` is now mandated.

--- a/changelog/237.bugfix.rst
+++ b/changelog/237.bugfix.rst
@@ -1,0 +1,1 @@
+Removed legacy sunpy version check and fallback scraper pattern in ``EOVSAClient`` since `sunpy[net]>=7.0` is now mandated.

--- a/radiospectra/net/sources/eovsa.py
+++ b/radiospectra/net/sources/eovsa.py
@@ -29,17 +29,10 @@ class EOVSAClient(GenericClient):
     <BLANKLINE>
     <BLANKLINE>
     """
-
-    from sunpy import __version__
-
-    if __version__ >= "6.1.0":
-        pattern = (
-            "https://ovsa.njit.edu/fits/synoptic/{{year:4d}}/{{month:2d}}/{{day:2d}}/"
-            "EOVSA_{{PolType:5l}}_{{year:4d}}{{month:2d}}{{day:2d}}.fts"
-        )
-    else:
-        baseurl = "https://ovsa.njit.edu/fits/synoptic/%Y/%m/%d/EOVSA_.*_%Y%m%d.fts"
-        pattern = "{}/synoptic/{year:4d}/{month:2d}/{day:2d}/EOVSA_{PolType:5l}_{year:4d}{month:2d}{day:2d}.fts"
+    pattern = (
+        "https://ovsa.njit.edu/fits/synoptic/{{year:4d}}/{{month:2d}}/{{day:2d}}/"
+        "EOVSA_{{PolType:5l}}_{{year:4d}}{{month:2d}}{{day:2d}}.fts"
+    )
     pol_map = {"Total": "TPall", "Cross": "XPall", "TPall": "Total", "XPall": "Cross"}
 
     @classmethod

--- a/radiospectra/net/sources/eovsa.py
+++ b/radiospectra/net/sources/eovsa.py
@@ -29,6 +29,7 @@ class EOVSAClient(GenericClient):
     <BLANKLINE>
     <BLANKLINE>
     """
+
     pattern = (
         "https://ovsa.njit.edu/fits/synoptic/{{year:4d}}/{{month:2d}}/{{day:2d}}/"
         "EOVSA_{{PolType:5l}}_{{year:4d}}{{month:2d}}{{day:2d}}.fts"


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->
Fixes #212
This PR cleans up the last remaining pieces of old scraper code now that `sunpy` 7.0+ is the mandated minimum version for the project. Most of the work was already covered in PR #142.

Changes:
- Removed the old `sunpy < 6.1.0` version check in `EOVSAClient`.
- Removed the outdated `baseurl` and string `pattern` definitions that were used to support the old scraper API format.


## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.

I'm looking into more things to see if there are any other places that might be affected. Let me know your thoughts on this @hayesla and @samaloney!
