### PR TITLE
Add spectrogram metadata classes

### DIFF
--- a/changelog/245.feature.rst
+++ b/changelog/245.feature.rst
@@ -1,0 +1,1 @@
+Add ``SpectrogramMetaABC`` and ``SpectrogramMeta`` metadata classes backed by ``ndcube.meta.NDMeta`` with instrument specific subclasses ``WAVESMeta`` and ``CALISTOMeta`` providing typed property access to spectrogram metadata.

--- a/changelog/245.feature.rst
+++ b/changelog/245.feature.rst
@@ -1,1 +1,1 @@
-Add ``SpectrogramMetaABC`` and ``SpectrogramMeta`` metadata classes backed by ``ndcube.meta.NDMeta`` with instrument specific subclasses ``WAVESMeta`` and ``CALISTOMeta`` providing typed property access to spectrogram metadata.
+Add ``SpectrogramMetaABC`` and ``SpectrogramMeta`` metadata classes backed by ``ndcube.meta.NDMeta`` with instrument specific subclasses for all supported instruments (``WAVESMeta``, ``CALISTOMeta``, ``EOVSAMeta``, ``RFSMeta``,etc) providing typed property access to spectrogram metadata.

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -8,7 +8,6 @@ __all__ = ["SpectrogramMetaABC", "SpectrogramMeta"]
 class SpectrogramMetaABC(NDMetaABC):
     """
     Abstract base class for all spectrogram metadata.
-    Maps to LC Radio Workshop metadata requirements.
     """
 
     # Identification
@@ -45,7 +44,7 @@ class SpectrogramMetaABC(NDMetaABC):
         """The source filename."""
         pass
 
-    # 2.2 Time
+    # Time
     @property
     @abc.abstractmethod
     def date_start(self):
@@ -77,7 +76,7 @@ class SpectrogramMetaABC(NDMetaABC):
         """Frequency resolution, both raw and current."""
         pass
 
-    # 2.4 Calibration and signal
+    # Calibration and signal
     @property
     @abc.abstractmethod
     def data_units(self):
@@ -96,14 +95,14 @@ class SpectrogramMetaABC(NDMetaABC):
         """Stokes parameter convention or polarization."""
         pass
 
-    # 2.5 Quality
+    # Quality
     @property
     @abc.abstractmethod
     def data_mask(self):
         """Data mask."""
         pass
 
-    # 2.6 Position
+    # Position
     @property
     @abc.abstractmethod
     def observer_location(self):
@@ -116,7 +115,6 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
     Base class for radio spectrogram metadata.
 
     Backed by `ndcube.meta.NDMeta` (a `dict` subclass).
-    Properties do key lookups with sensible defaults for optional fields.
     """
 
     @property

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -122,59 +122,59 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
     """
 
     @property
-    def instrument(self):
+    def instrument(self) -> str:
         return self["instrument"]
 
     @property
-    def observatory(self):
+    def observatory(self) -> str:
         return self["observatory"]
 
     @property
-    def detector(self):
+    def detector(self) -> str:
         return self["detector"]
 
     @property
-    def date_start(self):
+    def date_start(self) -> Time:
         return self["start_time"]
 
     @property
-    def date_end(self):
+    def date_end(self) -> Time:
         return self["end_time"]
 
     @property
-    def processing_level(self):
+    def processing_level(self) -> str | None:
         return self.get("processing_level")
 
     @property
-    def version(self):
+    def version(self) -> str | None:
         return self.get("version")
 
     @property
-    def source_filename(self):
+    def source_filename(self) -> str | None:
         return self.get("source_filename")
 
     @property
-    def temporal_resolution(self):
+    def temporal_resolution(self) -> Quantity:
         return self.get("temporal_resolution")
 
     @property
-    def frequency_range(self):
+    def frequency_range(self) -> Quantity:
         return self.get("wavelength")
 
     @property
-    def frequency_resolution(self):
+    def frequency_resolution(self) -> Quantity:
         return self.get("frequency_resolution")
 
     @property
-    def data_units(self):
+    def data_units(self) -> Unit:
         return self.get("data_units")
 
     @property
-    def calibration_state(self):
+    def calibration_state(self) -> str | None:
         return self.get("calibration_state")
 
     @property
-    def polarisation(self):
+    def polarisation(self) -> str | None:
         return self.get("polarisation")
 
     @property

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -1,0 +1,184 @@
+import abc
+
+from ndcube.meta import NDMeta, NDMetaABC
+
+__all__ = ["SpectrogramMetaABC", "SpectrogramMeta"]
+
+
+class SpectrogramMetaABC(NDMetaABC):
+    """
+    Abstract base class for all spectrogram metadata.
+    Maps to LC Radio Workshop metadata requirements.
+    """
+
+    # Identification
+    @property
+    @abc.abstractmethod
+    def instrument(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def observatory(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def detector(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def processing_level(self):
+        """The level to which the data has been processed."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def version(self):
+        """The data version."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def source_filename(self):
+        """The source filename."""
+        pass
+
+    # 2.2 Time
+    @property
+    @abc.abstractmethod
+    def date_start(self):
+        """The start time of the observation."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def date_end(self):
+        """The end time of the observation."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def temporal_resolution(self):
+        """Temporal resolution, both raw and current."""
+        pass
+
+    # Frequency
+    @property
+    @abc.abstractmethod
+    def frequency_range(self):
+        """Start and end frequencies of the observation."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def frequency_resolution(self):
+        """Frequency resolution, both raw and current."""
+        pass
+
+    # 2.4 Calibration and signal
+    @property
+    @abc.abstractmethod
+    def data_units(self):
+        """Units of the data (e.g. arbitrary, V^2/Hz, sfu, dB)."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def calibration_state(self):
+        """Calibration state."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def polarisation(self):
+        """Stokes parameter convention or polarization."""
+        pass
+
+    # 2.5 Quality
+    @property
+    @abc.abstractmethod
+    def data_mask(self):
+        """Data mask."""
+        pass
+
+    # 2.6 Position
+    @property
+    @abc.abstractmethod
+    def observer_location(self):
+        """Observer location."""
+        pass
+
+
+class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
+    """
+    Base class for radio spectrogram metadata.
+
+    Backed by `ndcube.meta.NDMeta` (a `dict` subclass).
+    Properties do key lookups with sensible defaults for optional fields.
+    """
+
+    @property
+    def instrument(self):
+        return self["instrument"]
+
+    @property
+    def observatory(self):
+        return self["observatory"]
+
+    @property
+    def detector(self):
+        return self["detector"]
+
+    @property
+    def date_start(self):
+        return self["start_time"]
+
+    @property
+    def date_end(self):
+        return self["end_time"]
+
+    @property
+    def processing_level(self):
+        return self.get("processing_level")
+
+    @property
+    def version(self):
+        return self.get("version")
+
+    @property
+    def source_filename(self):
+        return self.get("source_filename")
+
+    @property
+    def temporal_resolution(self):
+        return self.get("temporal_resolution")
+
+    @property
+    def frequency_range(self):
+        return self.get("wavelength")
+
+    @property
+    def frequency_resolution(self):
+        return self.get("frequency_resolution")
+
+    @property
+    def data_units(self):
+        return self.get("data_units")
+
+    @property
+    def calibration_state(self):
+        return self.get("calibration_state")
+
+    @property
+    def polarisation(self):
+        return self.get("polarisation")
+
+    @property
+    def data_mask(self):
+        return self.get("data_mask")
+
+    @property
+    def observer_location(self):
+        return self.get("observer_location")

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -2,8 +2,9 @@ import abc
 
 from ndcube.meta import NDMeta, NDMetaABC
 
+from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from astropy.units import Quantity, Unit
+from astropy.units import Quantity
 
 __all__ = ["SpectrogramMetaABC", "SpectrogramMeta"]
 
@@ -83,12 +84,6 @@ class SpectrogramMetaABC(NDMetaABC):
     # Calibration and signal
     @property
     @abc.abstractmethod
-    def data_units(self) -> Unit:
-        """Unit for the data"""
-        pass
-
-    @property
-    @abc.abstractmethod
     def calibration_state(self) -> str | None:
         """Calibration state."""
         pass
@@ -109,8 +104,8 @@ class SpectrogramMetaABC(NDMetaABC):
     # Position
     @property
     @abc.abstractmethod
-    def observer_location(self):
-        """Observer location."""
+    def observer_coordinate(self) -> SkyCoord | None:
+        """Observer coordinate."""
         pass
 
 
@@ -166,10 +161,6 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
         return self.get("frequency_resolution")
 
     @property
-    def data_units(self) -> Unit:
-        return self.get("data_units")
-
-    @property
     def calibration_state(self) -> str | None:
         return self.get("calibration_state")
 
@@ -182,5 +173,5 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
         return self.get("data_mask")
 
     @property
-    def observer_location(self):
-        return self.get("observer_location")
+    def observer_coordinate(self) -> SkyCoord | None:
+        return self.get("observer_coordinate")

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -2,6 +2,9 @@ import abc
 
 from ndcube.meta import NDMeta, NDMetaABC
 
+from astropy.time import Time
+from astropy.units import Quantity, Unit
+
 __all__ = ["SpectrogramMetaABC", "SpectrogramMeta"]
 
 
@@ -13,85 +16,86 @@ class SpectrogramMetaABC(NDMetaABC):
     # Identification
     @property
     @abc.abstractmethod
-    def instrument(self):
+    def instrument(self) -> str:
+        """Name of the instrument."""
         pass
 
     @property
     @abc.abstractmethod
-    def observatory(self):
+    def observatory(self) -> str:
+        """Name of the observatory."""
         pass
 
     @property
     @abc.abstractmethod
-    def detector(self):
+    def detector(self) -> str:
+        """Name of the detector."""
         pass
 
     @property
     @abc.abstractmethod
-    def processing_level(self):
+    def processing_level(self) -> str | None:
         """The level to which the data has been processed."""
         pass
 
     @property
     @abc.abstractmethod
-    def version(self):
+    def version(self) -> str | None:
         """The data version."""
         pass
 
     @property
     @abc.abstractmethod
-    def source_filename(self):
+    def source_filename(self) -> str | None:
         """The source filename."""
         pass
 
     # Time
     @property
     @abc.abstractmethod
-    def date_start(self):
-        """The start time of the observation."""
+    def date_start(self) -> Time:
+        """Start of the observation"""
         pass
 
     @property
     @abc.abstractmethod
-    def date_end(self):
-        """The end time of the observation."""
+    def date_end(self) -> Time:
+        """End of the observation"""
         pass
 
     @property
     @abc.abstractmethod
-    def temporal_resolution(self):
-        """Temporal resolution, both raw and current."""
+    def temporal_resolution(self) -> Quantity:
         pass
 
     # Frequency
     @property
     @abc.abstractmethod
-    def frequency_range(self):
-        """Start and end frequencies of the observation."""
+    def frequency_range(self) -> Quantity:
+        """Frequency range of observation"""
         pass
 
     @property
     @abc.abstractmethod
-    def frequency_resolution(self):
-        """Frequency resolution, both raw and current."""
+    def frequency_resolution(self) -> Quantity:
         pass
 
     # Calibration and signal
     @property
     @abc.abstractmethod
-    def data_units(self):
-        """Units of the data (e.g. arbitrary, V^2/Hz, sfu, dB)."""
+    def data_units(self) -> Unit:
+        """Unit for the data"""
         pass
 
     @property
     @abc.abstractmethod
-    def calibration_state(self):
+    def calibration_state(self) -> str | None:
         """Calibration state."""
         pass
 
     @property
     @abc.abstractmethod
-    def polarisation(self):
+    def polarisation(self) -> str | None:
         """Stokes parameter convention or polarization."""
         pass
 

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -66,19 +66,19 @@ class SpectrogramMetaABC(NDMetaABC):
 
     @property
     @abc.abstractmethod
-    def temporal_resolution(self) -> Quantity:
+    def temporal_resolution(self) -> Quantity | None:
         pass
 
     # Frequency
     @property
     @abc.abstractmethod
-    def frequency_range(self) -> Quantity:
+    def frequency_range(self) -> Quantity | None:
         """Frequency range of observation"""
         pass
 
     @property
     @abc.abstractmethod
-    def frequency_resolution(self) -> Quantity:
+    def frequency_resolution(self) -> Quantity | None:
         pass
 
     # Calibration and signal
@@ -149,15 +149,15 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
         return self.get("source_filename")
 
     @property
-    def temporal_resolution(self) -> Quantity:
+    def temporal_resolution(self) -> Quantity | None:
         return self.get("temporal_resolution")
 
     @property
-    def frequency_range(self) -> Quantity:
+    def frequency_range(self) -> Quantity | None:
         return self.get("wavelength")
 
     @property
-    def frequency_resolution(self) -> Quantity:
+    def frequency_resolution(self) -> Quantity | None:
         return self.get("frequency_resolution")
 
     @property

--- a/radiospectra/spectrogram/meta.py
+++ b/radiospectra/spectrogram/meta.py
@@ -35,6 +35,12 @@ class SpectrogramMetaABC(NDMetaABC):
 
     @property
     @abc.abstractmethod
+    def receiver(self) -> str | None:
+        """Name of the receiver."""
+        pass
+
+    @property
+    @abc.abstractmethod
     def processing_level(self) -> str | None:
         """The level to which the data has been processed."""
         pass
@@ -108,6 +114,12 @@ class SpectrogramMetaABC(NDMetaABC):
         """Observer coordinate."""
         pass
 
+    @property
+    @abc.abstractmethod
+    def background(self):
+        """The background subtracted from the data."""
+        pass
+
 
 class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
     """
@@ -130,11 +142,11 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
 
     @property
     def date_start(self) -> Time:
-        return self["start_time"]
+        return Time(self["start_time"])
 
     @property
     def date_end(self) -> Time:
-        return self["end_time"]
+        return Time(self["end_time"])
 
     @property
     def processing_level(self) -> str | None:
@@ -175,3 +187,11 @@ class SpectrogramMeta(NDMeta, SpectrogramMetaABC):
     @property
     def observer_coordinate(self) -> SkyCoord | None:
         return self.get("observer_coordinate")
+
+    @property
+    def receiver(self) -> str | None:
+        return self.get("detector")
+
+    @property
+    def background(self):
+        return self.get("background")

--- a/radiospectra/spectrogram/sources/callisto.py
+++ b/radiospectra/spectrogram/sources/callisto.py
@@ -1,5 +1,5 @@
 import astropy.units as u
-from astropy.coordinates.earth import EarthLocation
+from astropy.coordinates import EarthLocation, SkyCoord
 
 from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
@@ -11,8 +11,8 @@ class CALISTOMeta(SpectrogramMeta):
     """Metadata for e-CALLISTO spectrograms."""
 
     @property
-    def observer_location(self):
-        """The location of the observatory."""
+    def observer_coordinate(self) -> SkyCoord | None:
+        """The coordinate of the observatory."""
         fits_meta = self.get("fits_meta")
         if fits_meta:
             lat = fits_meta.get("OBS_LAT", 0) * u.deg * (1.0 if fits_meta.get("OBS_LAC") == "N" else -1.0)
@@ -49,7 +49,7 @@ class CALISTOSpectrogram(GenericSpectrogram):
 
     @property
     def observatory_location(self):
-        return self.meta.observer_location
+        return self.meta.observer_coordinate
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/callisto.py
+++ b/radiospectra/spectrogram/sources/callisto.py
@@ -49,12 +49,7 @@ class CALISTOSpectrogram(GenericSpectrogram):
 
     @property
     def observatory_location(self):
-        if hasattr(self.meta, "observer_location") and self.meta.observer_location is not None:
-            return self.meta.observer_location
-        lat = self.meta["fits_meta"]["OBS_LAT"] * u.deg * (1.0 if self.meta["fits_meta"]["OBS_LAC"] == "N" else -1.0)
-        lon = self.meta["fits_meta"]["OBS_LON"] * u.deg * (1.0 if self.meta["fits_meta"]["OBS_LOC"] == "E" else -1.0)
-        height = self.meta["fits_meta"]["OBS_ALT"] * u.m
-        return EarthLocation(lat=lat, lon=lon, height=height)
+        return self.meta.observer_location
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/callisto.py
+++ b/radiospectra/spectrogram/sources/callisto.py
@@ -1,9 +1,25 @@
 import astropy.units as u
 from astropy.coordinates.earth import EarthLocation
 
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["CALISTOSpectrogram"]
+__all__ = ["CALISTOSpectrogram", "CALISTOMeta"]
+
+
+class CALISTOMeta(SpectrogramMeta):
+    """Metadata for e-CALLISTO spectrograms."""
+
+    @property
+    def observer_location(self):
+        """The location of the observatory."""
+        fits_meta = self.get("fits_meta")
+        if fits_meta:
+            lat = fits_meta.get("OBS_LAT", 0) * u.deg * (1.0 if fits_meta.get("OBS_LAC") == "N" else -1.0)
+            lon = fits_meta.get("OBS_LON", 0) * u.deg * (1.0 if fits_meta.get("OBS_LOC") == "E" else -1.0)
+            height = fits_meta.get("OBS_ALT", 0) * u.m
+            return EarthLocation(lat=lat, lon=lon, height=height)
+        return None
 
 
 class CALISTOSpectrogram(GenericSpectrogram):
@@ -27,10 +43,14 @@ class CALISTOSpectrogram(GenericSpectrogram):
     """
 
     def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, CALISTOMeta):
+            meta = CALISTOMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
     def observatory_location(self):
+        if hasattr(self.meta, "observer_location") and self.meta.observer_location is not None:
+            return self.meta.observer_location
         lat = self.meta["fits_meta"]["OBS_LAT"] * u.deg * (1.0 if self.meta["fits_meta"]["OBS_LAC"] == "N" else -1.0)
         lon = self.meta["fits_meta"]["OBS_LON"] * u.deg * (1.0 if self.meta["fits_meta"]["OBS_LOC"] == "E" else -1.0)
         height = self.meta["fits_meta"]["OBS_ALT"] * u.m

--- a/radiospectra/spectrogram/sources/callisto.py
+++ b/radiospectra/spectrogram/sources/callisto.py
@@ -15,10 +15,18 @@ class CALISTOMeta(SpectrogramMeta):
         """The coordinate of the observatory."""
         fits_meta = self.get("fits_meta")
         if fits_meta:
-            lat = fits_meta.get("OBS_LAT", 0) * u.deg * (1.0 if fits_meta.get("OBS_LAC") == "N" else -1.0)
-            lon = fits_meta.get("OBS_LON", 0) * u.deg * (1.0 if fits_meta.get("OBS_LOC") == "E" else -1.0)
+            lat_val = fits_meta.get("OBS_LAT")
+            lon_val = fits_meta.get("OBS_LON")
+            if lat_val is None or lon_val is None:
+                return None
+            lat = lat_val * u.deg * (1.0 if fits_meta.get("OBS_LAC") == "N" else -1.0)
+            lon = lon_val * u.deg * (1.0 if fits_meta.get("OBS_LOC") == "E" else -1.0)
             height = fits_meta.get("OBS_ALT", 0) * u.m
-            return EarthLocation(lat=lat, lon=lon, height=height)
+            loc = EarthLocation(lat=lat, lon=lon, height=height)
+            obstime = self.get("start_time")
+            if obstime is not None:
+                return SkyCoord(loc.get_gcrs(obstime))
+            return SkyCoord(loc.get_itrs())
         return None
 
 

--- a/radiospectra/spectrogram/sources/eovsa.py
+++ b/radiospectra/spectrogram/sources/eovsa.py
@@ -1,6 +1,19 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["EOVSASpectrogram"]
+__all__ = ["EOVSASpectrogram", "EOVSAMeta"]
+
+
+class EOVSAMeta(SpectrogramMeta):
+    """Metadata for EOVSA spectrograms."""
+
+    @property
+    def polarisation(self) -> str | None:
+        """The polarisation of the observation."""
+        fits_meta = self.get("fits_meta")
+        if fits_meta:
+            return fits_meta.get("POLARIZA")
+        return None
 
 
 class EOVSASpectrogram(GenericSpectrogram):
@@ -22,11 +35,13 @@ class EOVSASpectrogram(GenericSpectrogram):
     """
 
     def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, EOVSAMeta):
+            meta = EOVSAMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
     def polarisation(self):
-        return self.meta["fits_meta"]["POLARIZA"]
+        return self.meta.polarisation
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/ilofar357.py
+++ b/radiospectra/spectrogram/sources/ilofar357.py
@@ -1,8 +1,24 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
 __all__ = [
     "ILOFARMode357Spectrogram",
+    "ILOFARMeta",
 ]
+
+
+class ILOFARMeta(SpectrogramMeta):
+    """Metadata for Irish LOFAR Station spectrograms."""
+
+    @property
+    def mode(self) -> int | None:
+        """The observation mode."""
+        return self.get("mode")
+
+    @property
+    def polarisation(self) -> str | None:
+        """The polarisation of the observation."""
+        return self.get("polarisation")
 
 
 class ILOFARMode357Spectrogram(GenericSpectrogram):
@@ -10,13 +26,18 @@ class ILOFARMode357Spectrogram(GenericSpectrogram):
     Irish LOFAR Station mode 357 Spectrogram
     """
 
+    def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, ILOFARMeta):
+            meta = ILOFARMeta(meta)
+        super().__init__(meta=meta, data=data, **kwargs)
+
     @property
     def mode(self):
-        return self.meta.get("mode")
+        return self.meta.mode
 
     @property
     def polarisation(self):
-        return self.meta.get("polarisation")
+        return self.meta.polarisation
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/psp_rfs.py
+++ b/radiospectra/spectrogram/sources/psp_rfs.py
@@ -1,6 +1,37 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["RFSSpectrogram"]
+__all__ = ["RFSSpectrogram", "RFSMeta"]
+
+
+class RFSMeta(SpectrogramMeta):
+    """Metadata for PSP FIELDS/RFS spectrograms."""
+
+    @property
+    def level(self) -> str | None:
+        """The data processing level."""
+        cdf_globals = self.get("cdf_globals")
+        if cdf_globals:
+            data_type = cdf_globals.get("Data_type")
+            if data_type is None:
+                return None
+            if isinstance(data_type, list) or hasattr(data_type, "tolist"):
+                data_type = data_type[0]
+            return data_type.split(">")[0]
+        return None
+
+    @property
+    def version(self) -> int | None:
+        """The data version."""
+        cdf_globals = self.get("cdf_globals")
+        if cdf_globals:
+            data_version = cdf_globals.get("Data_version")
+            if data_version is None:
+                return None
+            if isinstance(data_version, list) or hasattr(data_version, "tolist"):
+                data_version = data_version[0]
+            return int(data_version)
+        return None
 
 
 class RFSSpectrogram(GenericSpectrogram):
@@ -22,21 +53,17 @@ class RFSSpectrogram(GenericSpectrogram):
     """
 
     def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, RFSMeta):
+            meta = RFSMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
     def level(self):
-        data_type = self.meta["cdf_globals"]["Data_type"]
-        if isinstance(data_type, list) or hasattr(data_type, "tolist"):
-            data_type = data_type[0]
-        return data_type.split(">")[0]
+        return self.meta.level
 
     @property
     def version(self):
-        data_version = self.meta["cdf_globals"]["Data_version"]
-        if isinstance(data_version, list) or hasattr(data_version, "tolist"):
-            data_version = data_version[0]
-        return int(data_version)
+        return self.meta.version
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/psp_rfs.py
+++ b/radiospectra/spectrogram/sources/psp_rfs.py
@@ -8,7 +8,7 @@ class RFSMeta(SpectrogramMeta):
     """Metadata for PSP FIELDS/RFS spectrograms."""
 
     @property
-    def level(self) -> str | None:
+    def processing_level(self) -> str | None:
         """The data processing level."""
         cdf_globals = self.get("cdf_globals")
         if cdf_globals:
@@ -58,8 +58,8 @@ class RFSSpectrogram(GenericSpectrogram):
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
-    def level(self):
-        return self.meta.level
+    def processing_level(self):
+        return self.meta.processing_level
 
     @property
     def version(self):

--- a/radiospectra/spectrogram/sources/rpw.py
+++ b/radiospectra/spectrogram/sources/rpw.py
@@ -1,6 +1,13 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["RPWSpectrogram"]
+__all__ = ["RPWSpectrogram", "RPWMeta"]
+
+
+class RPWMeta(SpectrogramMeta):
+    """Metadata for Solar Orbiter RPW spectrograms."""
+
+    pass
 
 
 class RPWSpectrogram(GenericSpectrogram):
@@ -53,6 +60,11 @@ class RPWSpectrogram(GenericSpectrogram):
     >>> spec.plot()  #doctest: +REMOTE_DATA
     <matplotlib.collections.QuadMesh object at ...>
     """
+
+    def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, RPWMeta):
+            meta = RPWMeta(meta)
+        super().__init__(meta=meta, data=data, **kwargs)
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/rstn.py
+++ b/radiospectra/spectrogram/sources/rstn.py
@@ -1,6 +1,13 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["RSTNSpectrogram"]
+__all__ = ["RSTNSpectrogram", "RSTNMeta"]
+
+
+class RSTNMeta(SpectrogramMeta):
+    """Metadata for RSTN spectrograms."""
+
+    pass
 
 
 class RSTNSpectrogram(GenericSpectrogram):
@@ -20,6 +27,11 @@ class RSTNSpectrogram(GenericSpectrogram):
     >>> spec.plot()  #doctest: +REMOTE_DATA
     <matplotlib.collections.QuadMesh object at ...>
     """
+
+    def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, RSTNMeta):
+            meta = RSTNMeta(meta)
+        super().__init__(meta=meta, data=data, **kwargs)
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/swaves.py
+++ b/radiospectra/spectrogram/sources/swaves.py
@@ -1,6 +1,16 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["SWAVESSpectrogram"]
+__all__ = ["SWAVESSpectrogram", "SWAVESMeta"]
+
+
+class SWAVESMeta(SpectrogramMeta):
+    """Metadata for STEREO/SWAVES spectrograms."""
+
+    @property
+    def receiver(self) -> str | None:
+        """The name of the receiver."""
+        return self.get("detector")
 
 
 class SWAVESSpectrogram(GenericSpectrogram):
@@ -24,14 +34,14 @@ class SWAVESSpectrogram(GenericSpectrogram):
     """
 
     def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, SWAVESMeta):
+            meta = SWAVESMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
     def receiver(self):
-        """
-        The name of the receiver.
-        """
-        return self.meta["receiver"]
+        """The name of the receiver."""
+        return self.meta.receiver
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/swaves.py
+++ b/radiospectra/spectrogram/sources/swaves.py
@@ -7,10 +7,7 @@ __all__ = ["SWAVESSpectrogram", "SWAVESMeta"]
 class SWAVESMeta(SpectrogramMeta):
     """Metadata for STEREO/SWAVES spectrograms."""
 
-    @property
-    def receiver(self) -> str | None:
-        """The name of the receiver."""
-        return self.get("detector")
+    pass
 
 
 class SWAVESSpectrogram(GenericSpectrogram):
@@ -37,11 +34,6 @@ class SWAVESSpectrogram(GenericSpectrogram):
         if not isinstance(meta, SWAVESMeta):
             meta = SWAVESMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
-
-    @property
-    def receiver(self):
-        """The name of the receiver."""
-        return self.meta.receiver
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/tests/test_callisto.py
+++ b/radiospectra/spectrogram/sources/tests/test_callisto.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
-from astropy.coordinates import EarthLocation
+from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
@@ -252,8 +252,10 @@ def test_callisto(parse_path_moc):
     assert spec.end_time.datetime == datetime(2011, 6, 7, 6, 39)
     assert spec.wavelength.min.to(u.MHz) == 20 * u.MHz
     assert spec.wavelength.max.to(u.MHz).round(1) == 91.8 * u.MHz
-    assert spec.observatory_location.value.tolist() == (3801942.212601484, 528924.6036780173, 5077174.568618115)
-    assert spec.observatory_location.unit == u.m
+    loc = spec.observatory_location.itrs.earth_location
+    assert np.isclose(loc.lon.value, 7.92012977600098)
+    assert np.isclose(loc.lat.value, 53.0941390991211)
+    assert np.isclose(loc.height.value, 416.5)
 
 
 @mock.patch("sunpy.util.io.is_file")
@@ -496,8 +498,10 @@ def test_callisto_hour_rollover(hdul_moc, is_file_mock):
     assert spec.end_time.datetime == datetime(2011, 6, 8, 0, 1, 6, 0)
     assert spec.wavelength.min.to(u.MHz) == 20 * u.MHz
     assert spec.wavelength.max.to(u.MHz).round(1) == 91.8 * u.MHz
-    assert spec.observatory_location.value.tolist() == (3801942.212601484, 528924.6036780173, 5077174.568618115)
-    assert spec.observatory_location.unit == u.m
+    loc = spec.observatory_location.itrs.earth_location
+    assert np.isclose(loc.lon.value, 7.92012977600098)
+    assert np.isclose(loc.lat.value, 53.0941390991211)
+    assert np.isclose(loc.height.value, 416.5)
 
 
 @pytest.mark.remote_data
@@ -526,7 +530,8 @@ def test_callisto_meta():
         }
     )
     coord = meta.observer_coordinate
-    assert isinstance(coord, EarthLocation)
-    assert np.isclose(coord.lon.value, 7.92012977600098)
-    assert np.isclose(coord.lat.value, 53.0941390991211)
-    assert np.isclose(coord.height.value, 416.5)
+    assert isinstance(coord, SkyCoord)
+    loc = coord.earth_location
+    assert np.isclose(loc.lon.value, 7.92012977600098)
+    assert np.isclose(loc.lat.value, 53.0941390991211)
+    assert np.isclose(loc.height.value, 416.5)

--- a/radiospectra/spectrogram/sources/tests/test_callisto.py
+++ b/radiospectra/spectrogram/sources/tests/test_callisto.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
+from astropy.coordinates import EarthLocation
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
 
@@ -14,6 +15,7 @@ from sunpy.net import attrs as a
 
 from radiospectra.spectrogram import Spectrogram
 from radiospectra.spectrogram.sources import CALISTOSpectrogram
+from radiospectra.spectrogram.sources.callisto import CALISTOMeta
 
 
 @mock.patch("radiospectra.spectrogram.spectrogram_factory.parse_path")
@@ -509,3 +511,22 @@ def test_ecallisto_spectrogram_online():
     assert_quantity_allclose(spec.frequencies[0], 92.938 * u.MHz, rtol=1e-3)
     assert spec.frequencies[-1] == 45.0 * u.MHz
     assert spec.data.shape == (200, 3600)
+
+
+def test_callisto_meta():
+    meta = CALISTOMeta(
+        {
+            "fits_meta": {
+                "OBS_LAC": "N",
+                "OBS_LAT": 53.0941390991211,
+                "OBS_LOC": "E",
+                "OBS_LON": 7.92012977600098,
+                "OBS_ALT": 416.5,
+            }
+        }
+    )
+    coord = meta.observer_coordinate
+    assert isinstance(coord, EarthLocation)
+    assert np.isclose(coord.lon.value, 7.92012977600098)
+    assert np.isclose(coord.lat.value, 53.0941390991211)
+    assert np.isclose(coord.height.value, 416.5)

--- a/radiospectra/spectrogram/sources/tests/test_psp_rfs.py
+++ b/radiospectra/spectrogram/sources/tests/test_psp_rfs.py
@@ -120,7 +120,7 @@ def test_psp_rfs_lfr(parse_path_moc):
     assert spec.end_time.datetime == datetime(2019, 4, 10, 0, 1, 4, 997573)
     assert spec.wavelength.min.round(1) == 10.5 * u.kHz
     assert spec.wavelength.max == 1687.5 * u.kHz
-    assert spec.level == "L2"
+    assert spec.processing_level == "L2"
     assert spec.version == 1
 
 
@@ -228,7 +228,7 @@ def test_psp_rfs_hfr(parse_path_moc):
     assert spec.end_time.datetime == datetime(2019, 4, 10, 0, 1, 2, 758315)
     assert spec.wavelength.min == 1275.0 * u.kHz
     assert spec.wavelength.max == 19171.876 * u.kHz
-    assert spec.level == "L2"
+    assert spec.processing_level == "L2"
     assert spec.version == 1
 
 
@@ -249,12 +249,12 @@ def test_psp_rfs_spectrogram_online():
 def test_psp_rfs_real_data():
     """
     Test that reading a real PSP RFS file successfully parses the metadata dictionary
-    and allows access to properties like 'level' without throwing a KeyError.
+    and allows access to properties like 'processing_level' without throwing a KeyError.
 
     This ensures that the factory output uses the same CDF metadata key (``"cdf_globals"``).
     """
     query = Fido.search(a.Time("2020/01/01", "2020/01/31"), a.Instrument("rfs"))
     files = Fido.fetch(query[0, 0])
     spec = Spectrogram(files[0])
-    assert spec.level == "L2"
+    assert spec.processing_level == "L2"
     assert isinstance(spec.version, int)

--- a/radiospectra/spectrogram/sources/tests/test_waves.py
+++ b/radiospectra/spectrogram/sources/tests/test_waves.py
@@ -12,6 +12,7 @@ from sunpy.net import attrs as a
 
 from radiospectra.spectrogram import Spectrogram
 from radiospectra.spectrogram.sources import WAVESSpectrogram
+from radiospectra.spectrogram.sources.waves import WAVESMeta
 from radiospectra.spectrogram.spectrogram_factory import SpectrogramFactory
 
 
@@ -88,3 +89,16 @@ def test_waves_spectrogram_online():
     assert spec.frequencies[0] == 20.0 * u.kHz
     assert spec.frequencies[-1] == 1040.0 * u.kHz
     assert spec.data.shape == (256, 1440)
+
+
+def test_waves_meta():
+    meta = WAVESMeta(
+        {
+            "instrument": "WAVES",
+            "background": "test_bg",
+            "detector": "rad1",
+        }
+    )
+    assert meta.instrument == "WAVES"
+    assert meta.background == "test_bg"
+    assert meta.receiver == "rad1"

--- a/radiospectra/spectrogram/sources/waves.py
+++ b/radiospectra/spectrogram/sources/waves.py
@@ -1,6 +1,21 @@
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
-__all__ = ["WAVESSpectrogram"]
+__all__ = ["WAVESSpectrogram", "WAVESMeta"]
+
+
+class WAVESMeta(SpectrogramMeta):
+    """Metadata for WIND/WAVES spectrograms."""
+
+    @property
+    def background(self):
+        """The background subtracted from the data."""
+        return self.get("background")
+
+    @property
+    def receiver(self):
+        """The name of the receiver."""
+        return self.get("detector")
 
 
 class WAVESSpectrogram(GenericSpectrogram):
@@ -24,6 +39,8 @@ class WAVESSpectrogram(GenericSpectrogram):
     """
 
     def __init__(self, data, meta, **kwargs):
+        if not isinstance(meta, WAVESMeta):
+            meta = WAVESMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
 
     @property
@@ -31,14 +48,14 @@ class WAVESSpectrogram(GenericSpectrogram):
         """
         The name of the receiver.
         """
-        return self.meta["receiver"]
+        return getattr(self.meta, "receiver", self.meta.get("receiver"))
 
     @property
     def background(self):
         """
         The background subtracted from the data.
         """
-        return self.meta.bg
+        return getattr(self.meta, "background", self.meta.get("bg"))
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/sources/waves.py
+++ b/radiospectra/spectrogram/sources/waves.py
@@ -7,15 +7,7 @@ __all__ = ["WAVESSpectrogram", "WAVESMeta"]
 class WAVESMeta(SpectrogramMeta):
     """Metadata for WIND/WAVES spectrograms."""
 
-    @property
-    def background(self):
-        """The background subtracted from the data."""
-        return self.get("background")
-
-    @property
-    def receiver(self):
-        """The name of the receiver."""
-        return self.get("detector")
+    pass
 
 
 class WAVESSpectrogram(GenericSpectrogram):
@@ -42,20 +34,6 @@ class WAVESSpectrogram(GenericSpectrogram):
         if not isinstance(meta, WAVESMeta):
             meta = WAVESMeta(meta)
         super().__init__(meta=meta, data=data, **kwargs)
-
-    @property
-    def receiver(self):
-        """
-        The name of the receiver.
-        """
-        return getattr(self.meta, "receiver", self.meta.get("receiver"))
-
-    @property
-    def background(self):
-        """
-        The background subtracted from the data.
-        """
-        return getattr(self.meta, "background", self.meta.get("bg"))
 
     @classmethod
     def is_datasource_for(cls, data, meta, **kwargs):

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -5,6 +5,7 @@ from astropy.time import Time
 
 from radiospectra.exceptions import SpectraMetaValidationError
 from radiospectra.mixins import NonUniformImagePlotMixin, PcolormeshPlotMixin
+from radiospectra.spectrogram.meta import SpectrogramMeta
 from radiospectra.utils import build_spectrogram_wcs
 
 __all__ = ["GenericSpectrogram"]
@@ -30,6 +31,9 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
             cls._registry[cls] = cls.is_datasource_for
 
     def __init__(self, data, meta, wcs=None, **kwargs):
+        if not isinstance(meta, SpectrogramMeta):
+            meta = SpectrogramMeta(meta)
+
         if wcs is None:
             self._validate_meta(meta)
             wcs = build_spectrogram_wcs(self._time_axis_from_meta(meta), meta["freqs"]).wcs
@@ -40,42 +44,45 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         """
         The name of the observatory which recorded the spectrogram.
         """
-        return self.meta["observatory"].upper()
+        val = getattr(self.meta, "observatory", self.meta.get("observatory"))
+        return val.upper() if val else None
 
     @property
     def instrument(self):
         """
         The name of the instrument which recorded the spectrogram.
         """
-        return self.meta["instrument"].upper()
+        val = getattr(self.meta, "instrument", self.meta.get("instrument"))
+        return val.upper() if val else None
 
     @property
     def detector(self):
         """
         The detector which recorded the spectrogram.
         """
-        return self.meta["detector"].upper()
+        val = getattr(self.meta, "detector", self.meta.get("detector"))
+        return val.upper() if val else None
 
     @property
     def start_time(self):
         """
         The start time of the spectrogram.
         """
-        return self.meta["start_time"]
+        return getattr(self.meta, "date_start", self.meta.get("start_time"))
 
     @property
     def end_time(self):
         """
         The end time of the spectrogram.
         """
-        return self.meta["end_time"]
+        return getattr(self.meta, "date_end", self.meta.get("end_time"))
 
     @property
     def wavelength(self):
         """
         The wavelength range of the spectrogram.
         """
-        return self.meta["wavelength"]
+        return getattr(self.meta, "frequency_range", self.meta.get("wavelength"))
 
     @property
     def times(self):

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -64,6 +64,21 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         return val.upper() if val else None
 
     @property
+    def receiver(self):
+        """
+        The receiver which recorded the spectrogram.
+        """
+        val = self.meta.get("receiver")
+        return val.upper() if val else None
+
+    @property
+    def background(self):
+        """
+        The background subtracted from the data.
+        """
+        return self.meta.get("background")
+
+    @property
     def start_time(self):
         """
         The start time of the spectrogram.

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -44,7 +44,7 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         """
         The name of the observatory which recorded the spectrogram.
         """
-        val = getattr(self.meta, "observatory", self.meta.get("observatory"))
+        val = self.meta.get("observatory")
         return val.upper() if val else None
 
     @property
@@ -52,7 +52,7 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         """
         The name of the instrument which recorded the spectrogram.
         """
-        val = getattr(self.meta, "instrument", self.meta.get("instrument"))
+        val = self.meta.get("instrument")
         return val.upper() if val else None
 
     @property
@@ -60,7 +60,7 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         """
         The detector which recorded the spectrogram.
         """
-        val = getattr(self.meta, "detector", self.meta.get("detector"))
+        val = self.meta.get("detector")
         return val.upper() if val else None
 
     @property
@@ -68,21 +68,21 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         """
         The start time of the spectrogram.
         """
-        return getattr(self.meta, "date_start", self.meta.get("start_time"))
+        return self.meta.get("start_time")
 
     @property
     def end_time(self):
         """
         The end time of the spectrogram.
         """
-        return getattr(self.meta, "date_end", self.meta.get("end_time"))
+        return self.meta.get("end_time")
 
     @property
     def wavelength(self):
         """
         The wavelength range of the spectrogram.
         """
-        return getattr(self.meta, "frequency_range", self.meta.get("wavelength"))
+        return self.meta.get("wavelength")
 
     @property
     def times(self):

--- a/radiospectra/spectrogram/tests/test_meta.py
+++ b/radiospectra/spectrogram/tests/test_meta.py
@@ -1,0 +1,42 @@
+import pytest
+
+from radiospectra.spectrogram.meta import SpectrogramMeta
+
+
+def test_spectrogram_meta_required_keys():
+    meta = SpectrogramMeta(
+        {
+            "instrument": "test_inst",
+            "observatory": "test_obs",
+            "detector": "test_det",
+            "start_time": "2020-01-01",
+            "end_time": "2020-01-02",
+        }
+    )
+
+    assert meta.instrument == "test_inst"
+    assert meta.observatory == "test_obs"
+    assert meta.detector == "test_det"
+    assert meta.date_start == "2020-01-01"
+    assert meta.date_end == "2020-01-02"
+
+
+def test_spectrogram_meta_missing_required():
+    meta = SpectrogramMeta({})
+    with pytest.raises(KeyError):
+        _ = meta.instrument
+
+
+def test_spectrogram_meta_optional_keys():
+    meta = SpectrogramMeta(
+        {
+            "processing_level": "L2",
+            "version": "1.0",
+            "wavelength": "radio",
+        }
+    )
+
+    assert meta.processing_level == "L2"
+    assert meta.version == "1.0"
+    assert meta.frequency_range == "radio"
+    assert meta.temporal_resolution is None

--- a/radiospectra/spectrogram/tests/test_meta.py
+++ b/radiospectra/spectrogram/tests/test_meta.py
@@ -1,5 +1,10 @@
 import pytest
 
+import astropy.units as u
+from astropy.time import Time
+
+from sunpy.net import attrs as a
+
 from radiospectra.spectrogram.meta import SpectrogramMeta
 
 
@@ -17,8 +22,8 @@ def test_spectrogram_meta_required_keys():
     assert meta.instrument == "test_inst"
     assert meta.observatory == "test_obs"
     assert meta.detector == "test_det"
-    assert meta.date_start == "2020-01-01"
-    assert meta.date_end == "2020-01-02"
+    assert meta.date_start == Time("2020-01-01")
+    assert meta.date_end == Time("2020-01-02")
 
 
 def test_spectrogram_meta_missing_required():
@@ -32,11 +37,11 @@ def test_spectrogram_meta_optional_keys():
         {
             "processing_level": "L2",
             "version": "1.0",
-            "wavelength": "radio",
+            "wavelength": a.Wavelength(1 * u.kHz, 10 * u.kHz),
         }
     )
 
     assert meta.processing_level == "L2"
     assert meta.version == "1.0"
-    assert meta.frequency_range == "radio"
+    assert meta.frequency_range == a.Wavelength(1 * u.kHz, 10 * u.kHz)
     assert meta.temporal_resolution is None

--- a/radiospectra/spectrogram/tests/test_spectrogrambase.py
+++ b/radiospectra/spectrogram/tests/test_spectrogrambase.py
@@ -5,6 +5,11 @@ import numpy as np
 import pytest
 
 import astropy.units as u
+from astropy.time import Time
+
+from sunpy.net import attrs as a
+
+from radiospectra.spectrogram.spectrogrambase import GenericSpectrogram
 
 
 def test_plot_mixed_frequency_units_on_same_axes(make_spectrogram):
@@ -132,3 +137,32 @@ def test_plotim_uses_time_support_for_datetime_conversion(make_spectrogram):
     np.testing.assert_allclose(x_values, expected_tt)
     np.testing.assert_allclose(y_values, spec.frequencies.value)
     np.testing.assert_allclose(image, spec.data)
+
+
+def test_generic_spectrogram_from_dict():
+    """Test creating a GenericSpectrogram from a raw dict and check properties/types/slicing."""
+    times = Time("2021-01-01T00:00:00") + np.arange(10) * u.s
+    freqs = np.linspace(10, 20, 5) * u.MHz
+    data = np.random.rand(5, 10)
+
+    meta_dict = {
+        "instrument": "TestInstrument",
+        "observatory": "TestObservatory",
+        "detector": "TestDetector",
+        "start_time": times[0],
+        "end_time": times[-1],
+        "wavelength": a.Wavelength(freqs[0], freqs[-1]),
+        "times": times,
+        "freqs": freqs,
+    }
+
+    spec = GenericSpectrogram(data, meta_dict)
+    assert spec.instrument == "TESTINSTRUMENT"
+    assert spec.observatory == "TESTOBSERVATORY"
+    assert spec.detector == "TESTDETECTOR"
+    assert isinstance(spec.start_time, Time)
+    assert spec.start_time == times[0]
+    assert isinstance(spec.end_time, Time)
+    assert spec.end_time == times[-1]
+    sliced = spec[1:3, 2:5]
+    assert sliced.meta["instrument"] == "TestInstrument"


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->
Fixes #243 

Implementing a metadata class hierarchy for radiospectra, following the pattern used in [sunraster](https://github.com/sunpy/sunraster/blob/main/sunraster/meta.py) and the [LC Radio Workshop metadata requirements](https://lc-radio-workshop.github.io/requirements/).
I tried to make some flowcharts as well, will attach them too.

Changes:

- Added `SpectrogramMetaABC` and `SpectrogramMeta` (backed by NDMeta) in `radiospectra/spectrogram/meta.py`
- Added instrument specific subclasses (`WAVESMeta`, `SWAVESMeta`, `CALISTOMeta`, `EOVSAMeta`, `RSTNMeta`)
- Updated `GenericSpectrogram` to wrap raw dict metadata into `SpectrogramMeta` automatically
- Added tests for the new meta class


## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [x] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [x] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.

This is an initial draft, so I've just tried to make the changes in WAVES and CALISTO, if it looks in the right direction then I'll add the remaining subclasses also. Let me know your thoughts on this @samaloney and @hayesla.
