### PR TITLE
Add crop_time and crop_freq wrappers to GenericSpectrogram

### DIFF
--- a/changelog/256.feature.rst
+++ b/changelog/256.feature.rst
@@ -1,0 +1,1 @@
+Add `crop_time` and `crop_freq` wrappers to `GenericSpectrogram` to allow easy cropping of a spectrogram along a single axis.

--- a/changelog/256.feature.rst
+++ b/changelog/256.feature.rst
@@ -1,1 +1,1 @@
-Add `crop_time` and `crop_freq` wrappers to `GenericSpectrogram` to allow easy cropping of a spectrogram along a single axis.
+Add `~radiospectra.spectrogram.spectrogrambase.GenericSpectrogram.crop_time` and `~radiospectra.spectrogram.spectrogrambase.GenericSpectrogram.crop_freq` to allow easy cropping of a spectrogram along a single axis.

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -115,12 +115,36 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
     def crop_time(self, start_time, end_time):
         """
         Crop the spectrogram by time.
+
+        Parameters
+        ----------
+        start_time : `astropy.time.Time`
+            The start time of the crop.
+        end_time : `astropy.time.Time`
+            The end time of the crop.
+
+        Returns
+        -------
+        `radiospectra.spectrogram.GenericSpectrogram`
+            The cropped spectrogram.
         """
         return self.crop((start_time, None), (end_time, None))
 
     def crop_freq(self, low_freq, high_freq):
         """
         Crop the spectrogram by frequency.
+
+        Parameters
+        ----------
+        low_freq : `astropy.coordinates.SpectralCoord`
+            The low frequency of the crop.
+        high_freq : `astropy.coordinates.SpectralCoord`
+            The high frequency of the crop.
+
+        Returns
+        -------
+        `radiospectra.spectrogram.GenericSpectrogram`
+            The cropped spectrogram.
         """
         if not isinstance(low_freq, SpectralCoord):
             low_freq = SpectralCoord(low_freq)

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -128,6 +128,8 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
         `radiospectra.spectrogram.GenericSpectrogram`
             The cropped spectrogram.
         """
+        start_time = Time(start_time)
+        end_time = Time(end_time)
         return self.crop((start_time, None), (end_time, None))
 
     def crop_freq(self, low_freq, high_freq):
@@ -136,9 +138,9 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
 
         Parameters
         ----------
-        low_freq : `astropy.coordinates.SpectralCoord`
+        low_freq : `astropy.units.Quantity` or `astropy.coordinates.SpectralCoord`
             The low frequency of the crop.
-        high_freq : `astropy.coordinates.SpectralCoord`
+        high_freq : `astropy.units.Quantity` or `astropy.coordinates.SpectralCoord`
             The high frequency of the crop.
 
         Returns

--- a/radiospectra/spectrogram/spectrogrambase.py
+++ b/radiospectra/spectrogram/spectrogrambase.py
@@ -1,6 +1,7 @@
 import ndcube
 
 import astropy.units as u
+from astropy.coordinates import SpectralCoord
 from astropy.time import Time
 
 from radiospectra.exceptions import SpectraMetaValidationError
@@ -110,6 +111,23 @@ class GenericSpectrogram(PcolormeshPlotMixin, NonUniformImagePlotMixin, ndcube.N
                 return meta["start_time"] + times
             return meta["start_time"] + times * u.s
         return Time(times)
+
+    def crop_time(self, start_time, end_time):
+        """
+        Crop the spectrogram by time.
+        """
+        return self.crop((start_time, None), (end_time, None))
+
+    def crop_freq(self, low_freq, high_freq):
+        """
+        Crop the spectrogram by frequency.
+        """
+        if not isinstance(low_freq, SpectralCoord):
+            low_freq = SpectralCoord(low_freq)
+        if not isinstance(high_freq, SpectralCoord):
+            high_freq = SpectralCoord(high_freq)
+
+        return self.crop((None, low_freq), (None, high_freq))
 
     def __repr__(self):
         return (

--- a/radiospectra/spectrogram/tests/test_spectrogrambase.py
+++ b/radiospectra/spectrogram/tests/test_spectrogrambase.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import astropy.units as u
+from astropy.time import Time
 
 
 def test_plot_mixed_frequency_units_on_same_axes(make_spectrogram):
@@ -132,3 +133,37 @@ def test_plotim_uses_time_support_for_datetime_conversion(make_spectrogram):
     np.testing.assert_allclose(x_values, expected_tt)
     np.testing.assert_allclose(y_values, spec.frequencies.value)
     np.testing.assert_allclose(image, spec.data)
+
+
+def test_crop_time(make_spectrogram):
+    """Test cropping a spectrogram by time."""
+    times = Time("2021-01-01T00:00:00") + np.arange(10) * u.s
+    freqs = np.linspace(10, 20, 5) * u.MHz
+    data = np.random.rand(5, 10)
+    spec = make_spectrogram(freqs, data=data, times=times)
+
+    start = times[2]
+    end = times[5]
+
+    cropped = spec.crop_time(start, end)
+    assert cropped.shape == (5, 4)
+    assert cropped.times[0] == start
+    assert cropped.times[-1] == end
+    assert (cropped.frequencies == spec.frequencies).all()
+
+
+def test_crop_freq(make_spectrogram):
+    """Test cropping a spectrogram by frequency."""
+    times = Time("2021-01-01T00:00:00") + np.arange(10) * u.s
+    freqs = np.linspace(10, 20, 5) * u.MHz
+    data = np.random.rand(5, 10)
+    spec = make_spectrogram(freqs, data=data, times=times)
+
+    low = freqs[1]
+    high = freqs[3]
+
+    cropped = spec.crop_freq(low, high)
+    assert cropped.shape == (3, 10)
+    assert cropped.frequencies[0] == low
+    assert cropped.frequencies[-1] == high
+    assert (cropped.times == spec.times).all()


### PR DESCRIPTION
## PR Description

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->
Fixes #72 
This PR adds `crop_time` and `crop_freq` methods to `GenericSpectrogram` to make cropping along a single axis

Changes
- Added `crop_time(start_time, end_time)` to crop the time axis while keeping all frequency bins.
- Added `crop_freq(low_freq, high_freq)` to crop the frequency axis while keeping all time samples. Also `crop_freq` automatically converts `Quantity` inputs to `SpectralCoord`.
- Added tests for both methods to verify the cropping behavior.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [ ] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [x] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.